### PR TITLE
Add Character escape of SaTySFi spec.

### DIFF
--- a/satysfi.lua
+++ b/satysfi.lua
@@ -14,7 +14,7 @@
 
 -- Character escaping
 local function escape(s, in_attribute)
-    return s:gsub("[<>&\"*{}\\|%%\\*;#$\\@`]",
+    return s:gsub("[<>&\"*{}\\|%%\\*;#$\\\\@`]",
     function(x)
       if x == '*' then
         return "\\*"

--- a/satysfi.lua
+++ b/satysfi.lua
@@ -14,10 +14,36 @@
 
 -- Character escaping
 local function escape(s, in_attribute)
-  return s:gsub("[<>&\"*]",
+    return s:gsub("[<>&\"*{}\\|%%\\*;#$\\@`]",
     function(x)
       if x == '*' then
         return "\\*"
+      elseif x == '{' then
+        return "\\{"
+      elseif x == '}' then
+        return "\\}"
+      elseif x == '<' then
+        return "\\<"
+      elseif x == '>' then
+        return "\\>"
+      elseif x == '|' then
+        return "\\|"
+      elseif x == '%' then
+        return "\\%"
+      elseif x == '*' then
+        return "\\*"
+      elseif x == ';' then
+        return "\\;"
+      elseif x == '#' then
+        return "\\#"
+      elseif x == '$' then
+        return "\\$"
+      elseif x == '\\' then
+        return "\\\\"
+      elseif x == '@' then
+        return "\\@"
+      elseif x == '`' then
+        return "\\`"
       else
         return x
       end


### PR DESCRIPTION
Add Character escape in accordance to SATySFi Book pp.15.

Test fixture is:

```
{

}

<

char>

char|

%

char*

;

char#

$

\\char

@

`
```
( `char` is escape pattern for Markdown syntax.  )

Output:

![image](https://user-images.githubusercontent.com/145814/88457411-11bf9680-cec1-11ea-8db1-88e8fc3863bf.png)

